### PR TITLE
Specify assumptions using assert

### DIFF
--- a/src/main/java/bocchi/Bocchi.java
+++ b/src/main/java/bocchi/Bocchi.java
@@ -79,6 +79,7 @@ public class Bocchi {
                     "Cause it seems to be out of bounds. ＞﹏＜");
         }
 
+        assert index >= 0 && index < taskList.size() : "Index out of bounds";
         Task task = taskList.getTask(index);
         task.markAsDone();
 
@@ -98,6 +99,7 @@ public class Bocchi {
                     "Cause it seems to be out of bounds. ＞﹏＜");
         }
 
+        assert index >= 0 && index < taskList.size() : "Index out of bounds";
         Task task = taskList.getTask(index);
         task.markAsUnDone();
 
@@ -117,6 +119,7 @@ public class Bocchi {
                     "Cause it seems to be out of bounds. ＞﹏＜");
         }
 
+        assert index >= 0 && index < taskList.size() : "Index out of bounds";
         Task task = taskList.removeTask(index);
 
         return "I have removed the task!";

--- a/src/main/java/bocchi/command/Parser.java
+++ b/src/main/java/bocchi/command/Parser.java
@@ -23,13 +23,24 @@ public class Parser {
         if (commandAndParams.length == 1) { // no params at all
             param = null;
         } else {
+            assert commandAndParams.length == 2 : "commandAndParams should have length either 1 or 2";
+
             String paramString = commandAndParams[1];
             String[] paramAndKeywordParams = paramString.split(" +(?=\\/)"); // split params
+
+            assert paramAndKeywordParams.length >= 1 : "paramAndKeywordParams should have length >= 1";
+
             param = paramAndKeywordParams[0]; // extract param
             for (int i = 1; i < paramAndKeywordParams.length; i++) { // extract keyword params
                 String keywordParamString = paramAndKeywordParams[i];
                 String[] keyAndValue = keywordParamString.split(" +", 2); // split key and value
-                keywordParams.put(keyAndValue[0].substring(1), keyAndValue[1]);
+
+                assert keyAndValue.length >= 1 : "keyAndValue should have length >= 1";
+
+                String key = keyAndValue[0].substring(1); // remove the leading '/'
+                String value = keyAndValue.length == 2 ? keyAndValue[1] : null; // extract value if it is specified
+
+                keywordParams.put(key, value);
             }
         }
 


### PR DESCRIPTION
Bocchi.java:
Commands taking a task index uses guard condition to avoid
 out-of-bound access.

It is clearer if conditions on the index is explicitly specified.

Let's add assert statements at the start of each happy path.

Parser.java:
The parse() method contains assumptions on the length of lists returned by String::split().

Such assumptions should be explicitly written so that future maintainers can understand the logic more easily.

Let's add assert statements on list lengths.